### PR TITLE
Make format sniffers initialization public

### DIFF
--- a/Sources/Shared/Toolkit/Format/Sniffers/AudioFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/AudioFormatSniffer.swift
@@ -8,6 +8,8 @@ import Foundation
 
 /// Sniffs audio formats.
 public class AudioFormatSniffer: FormatSniffer {
+    public init() {}
+    
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if hints.hasFileExtension("aac") || hints.hasMediaType("audio/aac") {
             return Format(specifications: .aac, mediaType: .aac, fileExtension: "aac")

--- a/Sources/Shared/Toolkit/Format/Sniffers/AudioFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/AudioFormatSniffer.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Sniffs audio formats.
 public class AudioFormatSniffer: FormatSniffer {
     public init() {}
-    
+
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if hints.hasFileExtension("aac") || hints.hasMediaType("audio/aac") {
             return Format(specifications: .aac, mediaType: .aac, fileExtension: "aac")

--- a/Sources/Shared/Toolkit/Format/Sniffers/BitmapFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/BitmapFormatSniffer.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Sniffs bitmap formats.
 public class BitmapFormatSniffer: FormatSniffer {
     public init() {}
-    
+
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if hints.hasFileExtension("avif", "avifs") || hints.hasMediaType("image/avif") {
             return Format(specifications: .avif, mediaType: .avif, fileExtension: "avif")

--- a/Sources/Shared/Toolkit/Format/Sniffers/BitmapFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/BitmapFormatSniffer.swift
@@ -8,6 +8,8 @@ import Foundation
 
 /// Sniffs bitmap formats.
 public class BitmapFormatSniffer: FormatSniffer {
+    public init() {}
+    
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if hints.hasFileExtension("avif", "avifs") || hints.hasMediaType("image/avif") {
             return Format(specifications: .avif, mediaType: .avif, fileExtension: "avif")

--- a/Sources/Shared/Toolkit/Format/Sniffers/HTMLFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/HTMLFormatSniffer.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Sniffs an HTML or XHTML document.
 public struct HTMLFormatSniffer: FormatSniffer {
     public init() {}
-    
+
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if
             hints.hasFileExtension("htm", "html") ||

--- a/Sources/Shared/Toolkit/Format/Sniffers/HTMLFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/HTMLFormatSniffer.swift
@@ -8,6 +8,8 @@ import Foundation
 
 /// Sniffs an HTML or XHTML document.
 public struct HTMLFormatSniffer: FormatSniffer {
+    public init() {}
+    
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if
             hints.hasFileExtension("htm", "html") ||

--- a/Sources/Shared/Toolkit/Format/Sniffers/JSONFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/JSONFormatSniffer.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Sniffs a JSON document.
 public struct JSONFormatSniffer: FormatSniffer {
     public init() {}
-    
+
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if
             hints.hasFileExtension("json") ||

--- a/Sources/Shared/Toolkit/Format/Sniffers/JSONFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/JSONFormatSniffer.swift
@@ -8,6 +8,8 @@ import Foundation
 
 /// Sniffs a JSON document.
 public struct JSONFormatSniffer: FormatSniffer {
+    public init() {}
+    
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if
             hints.hasFileExtension("json") ||

--- a/Sources/Shared/Toolkit/Format/Sniffers/LCPLicenseFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/LCPLicenseFormatSniffer.swift
@@ -8,6 +8,8 @@ import Foundation
 
 /// Sniffs an LCP License Document.
 public struct LCPLicenseFormatSniffer: FormatSniffer {
+    public init() {}
+    
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if
             hints.hasFileExtension("lcpl") ||

--- a/Sources/Shared/Toolkit/Format/Sniffers/LCPLicenseFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/LCPLicenseFormatSniffer.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Sniffs an LCP License Document.
 public struct LCPLicenseFormatSniffer: FormatSniffer {
     public init() {}
-    
+
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if
             hints.hasFileExtension("lcpl") ||

--- a/Sources/Shared/Toolkit/Format/Sniffers/LanguageFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/LanguageFormatSniffer.swift
@@ -8,7 +8,7 @@ import Foundation
 
 public class LanguageFormatSniffer: FormatSniffer {
     public init() {}
-    
+
     public func sniffHints(_ hints: FormatHints) -> Format? {
         // JavaScript
         if

--- a/Sources/Shared/Toolkit/Format/Sniffers/LanguageFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/LanguageFormatSniffer.swift
@@ -7,6 +7,8 @@
 import Foundation
 
 public class LanguageFormatSniffer: FormatSniffer {
+    public init() {}
+    
     public func sniffHints(_ hints: FormatHints) -> Format? {
         // JavaScript
         if

--- a/Sources/Shared/Toolkit/Format/Sniffers/OPDSFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/OPDSFormatSniffer.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Sniffs OPDS documents.
 public class OPDSFormatSniffer: FormatSniffer {
     public init() {}
-    
+
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if hints.hasMediaType("application/atom+xml;type=entry;profile=opds-catalog") {
             return opds1Entry

--- a/Sources/Shared/Toolkit/Format/Sniffers/OPDSFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/OPDSFormatSniffer.swift
@@ -8,6 +8,8 @@ import Foundation
 
 /// Sniffs OPDS documents.
 public class OPDSFormatSniffer: FormatSniffer {
+    public init() {}
+    
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if hints.hasMediaType("application/atom+xml;type=entry;profile=opds-catalog") {
             return opds1Entry

--- a/Sources/Shared/Toolkit/Format/Sniffers/PDFFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/PDFFormatSniffer.swift
@@ -11,7 +11,7 @@ import Foundation
 /// Reference: https://www.loc.gov/preservation/digital/formats/fdd/fdd000123.shtml
 public struct PDFFormatSniffer: FormatSniffer {
     public init() {}
-    
+
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if
             hints.hasFileExtension("pdf") ||

--- a/Sources/Shared/Toolkit/Format/Sniffers/PDFFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/PDFFormatSniffer.swift
@@ -10,6 +10,8 @@ import Foundation
 ///
 /// Reference: https://www.loc.gov/preservation/digital/formats/fdd/fdd000123.shtml
 public struct PDFFormatSniffer: FormatSniffer {
+    public init() {}
+    
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if
             hints.hasFileExtension("pdf") ||

--- a/Sources/Shared/Toolkit/Format/Sniffers/RARFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/RARFormatSniffer.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Sniffs a RAR file.
 public struct RARFormatSniffer: FormatSniffer {
     public init() {}
-    
+
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if
             hints.hasFileExtension("rar") ||

--- a/Sources/Shared/Toolkit/Format/Sniffers/RARFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/RARFormatSniffer.swift
@@ -8,6 +8,8 @@ import Foundation
 
 /// Sniffs a RAR file.
 public struct RARFormatSniffer: FormatSniffer {
+    public init() {}
+    
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if
             hints.hasFileExtension("rar") ||

--- a/Sources/Shared/Toolkit/Format/Sniffers/RPFFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/RPFFormatSniffer.swift
@@ -8,6 +8,8 @@ import Foundation
 
 /// Sniffs a Readium Web Publication package.
 public struct RPFFormatSniffer: FormatSniffer {
+    public init() {}
+    
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if hints.hasMediaType("application/audiobook+zip") || hints.hasFileExtension("audiobook") {
             return audiobook

--- a/Sources/Shared/Toolkit/Format/Sniffers/RPFFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/RPFFormatSniffer.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Sniffs a Readium Web Publication package.
 public struct RPFFormatSniffer: FormatSniffer {
     public init() {}
-    
+
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if hints.hasMediaType("application/audiobook+zip") || hints.hasFileExtension("audiobook") {
             return audiobook

--- a/Sources/Shared/Toolkit/Format/Sniffers/RWPMFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/RWPMFormatSniffer.swift
@@ -8,6 +8,8 @@ import Foundation
 
 /// Sniffs a Readium Web Publication Manifest.
 public struct RWPMFormatSniffer: FormatSniffer {
+    public init() {}
+    
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if hints.hasMediaType("application/webpub+json") {
             return webpub

--- a/Sources/Shared/Toolkit/Format/Sniffers/RWPMFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/RWPMFormatSniffer.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Sniffs a Readium Web Publication Manifest.
 public struct RWPMFormatSniffer: FormatSniffer {
     public init() {}
-    
+
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if hints.hasMediaType("application/webpub+json") {
             return webpub

--- a/Sources/Shared/Toolkit/Format/Sniffers/XMLFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/XMLFormatSniffer.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Sniffs an XML document.
 public struct XMLFormatSniffer: FormatSniffer {
     public init() {}
-    
+
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if
             hints.hasFileExtension("xml") ||

--- a/Sources/Shared/Toolkit/Format/Sniffers/XMLFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/XMLFormatSniffer.swift
@@ -8,6 +8,8 @@ import Foundation
 
 /// Sniffs an XML document.
 public struct XMLFormatSniffer: FormatSniffer {
+    public init() {}
+    
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if
             hints.hasFileExtension("xml") ||

--- a/Sources/Shared/Toolkit/Format/Sniffers/ZIPFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/ZIPFormatSniffer.swift
@@ -9,7 +9,7 @@ import Foundation
 /// Sniffs a ZIP file.
 public struct ZIPFormatSniffer: FormatSniffer {
     public init() {}
-    
+
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if
             hints.hasFileExtension("zip") ||

--- a/Sources/Shared/Toolkit/Format/Sniffers/ZIPFormatSniffer.swift
+++ b/Sources/Shared/Toolkit/Format/Sniffers/ZIPFormatSniffer.swift
@@ -8,6 +8,8 @@ import Foundation
 
 /// Sniffs a ZIP file.
 public struct ZIPFormatSniffer: FormatSniffer {
+    public init() {}
+    
     public func sniffHints(_ hints: FormatHints) -> Format? {
         if
             hints.hasFileExtension("zip") ||


### PR DESCRIPTION
### The Problem

While it's possible to create and use a custom format sniffer, it's not possible to use the default format sniffers since the initialization of some of the format sniffers is internal.

### The Solution

To fix the issue, I added public initialization to some of the default format sniffers.